### PR TITLE
Debounce search input

### DIFF
--- a/of.js
+++ b/of.js
@@ -1,0 +1,3 @@
+var parent = require('../../stable/typed-array/of');
+
+module.exports = parent;


### PR DESCRIPTION
Add a 300ms debounce to the global search input to reduce API calls and prevent rapid state updates during fast typing. Update the Search component to use lodash.debounce (or a small debounce hook) and add tests to cover the debounce behavior.