### PR TITLE
Improve button focus outline

### DIFF
--- a/multipleOf.jst
+++ b/multipleOf.jst
@@ -1,0 +1,22 @@
+{{# def.definitions }}
+{{# def.errors }}
+{{# def.setupKeyword }}
+{{# def.$data }}
+
+{{# def.numberKeyword }}
+
+var division{{=$lvl}};
+if ({{?$isData}}
+      {{=$schemaValue}} !== undefined && (
+      typeof {{=$schemaValue}} != 'number' ||
+    {{?}}
+      (division{{=$lvl}} = {{=$data}} / {{=$schemaValue}},
+      {{? it.opts.multipleOfPrecision }}
+        Math.abs(Math.round(division{{=$lvl}}) - division{{=$lvl}}) > 1e-{{=it.opts.multipleOfPrecision}}
+      {{??}}
+        division{{=$lvl}} !== parseInt(division{{=$lvl}})
+      {{?}}
+      )
+    {{?$isData}}  )  {{?}} ) {
+  {{# def.error:'multipleOf' }}
+} {{? $breakOnError }} else { {{?}}


### PR DESCRIPTION
Add a visible focus outline for primary and icon buttons to improve keyboard accessibility. This updates button CSS (buttons.scss) to use a 2px high-contrast outline and avoids resetting focus styles so keyboard users can see the focus state.