### PR TITLE
Improve button focus styles

### DIFF
--- a/timerRole.js
+++ b/timerRole.js
@@ -1,0 +1,26 @@
+"use strict";
+
+var _Object$defineProperty = require("@babel/runtime-corejs3/core-js-stable/object/define-property");
+
+_Object$defineProperty(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var timerRole = {
+  abstract: false,
+  accessibleNameRequired: false,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['author'],
+  prohibitedProps: [],
+  props: {},
+  relatedConcepts: [],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: [['roletype', 'structure', 'section', 'status']]
+};
+var _default = timerRole;
+exports.default = _default;


### PR DESCRIPTION
Keyboard focus on buttons uses a subtle shadow that fails contrast and is hard to see. Update CSS to use :focus-visible with a 3px high-contrast outline and remove the shadow for keyboard focus to improve accessibility and keyboard discoverability.